### PR TITLE
Allow periods in speech text

### DIFF
--- a/alexa_remote_control.sh
+++ b/alexa_remote_control.sh
@@ -309,7 +309,7 @@ case "$COMMAND" in
 			;;
 	speak:*)
 			SEQUENCECMD='Alexa.Speak'
-			TTS=$(echo ${COMMAND##*:} | sed -r 's/[^-a-zA-Z0-9_,?! ]//g' | sed 's/ /_/g')
+			TTS=$(echo ${COMMAND##*:} | sed -r 's/[^-a-zA-Z0-9_.,?! ]//g' | sed 's/ /_/g')
 			TTS=",\\\"textToSpeak\\\":\\\"${TTS}\\\""
 			;;
 	automation:*)


### PR DESCRIPTION
The stream editor command is removing periods from the text causing alexa to speak without pausing through multiple sentences. This fix allows alexa to pause as the periods are left in from the original text.